### PR TITLE
FUJ-3165: improvements to Greenhouse tap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-greenhouse",
-    version="0.1.4",
+    version="0.1.5",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
The tap error that we're seeing, "Connection reset by peer", seems to be due to a Python networking bug. In investigating the state of this tap, we're never actually updating the bookmarks, so every tap run queries Greenhouse for the entire history of changes!  My working assumption is that by significantly reducing our network requests, we're much less likely to run into this bug.

Made the following changes:

1.  Consolidated all the duplicate code in Stream subclasses (the `paging_get` and `sync` methods)
2. Updated some of the values for `replication key` (the object field with the update timestamp) and `incremental_search_key` (the query parameter to use for the list method) based on the current Greenhouse API docs at https://developers.greenhouse.io/harvest.html
3. Actually call the update_bookmark method so that state gets saved.

Here's what the state looks like at the end of a local run:
`{"type": "STATE", "value": {"bookmarks": {"candidates": {"last_activity": "2022-12-19T12:50:53"}, "offers": {"updated_at": "2022-12-19T12:50:54"}, "eeoc": {"submitted_at": "2022-12-19T12:51:02"}, "job_posts": {"updated_at": "2022-12-19T12:51:03"}, "users": {"updated_at": "2022-12-19T12:51:03"}, "interviews": {"updated_at": "2022-12-19T12:51:10"}, "scorecards": {"updated_at": "2022-12-19T12:51:27"}, "applications": {"last_activity_at": "2022-12-19T12:52:07"}, "jobs": {"updated_at": "2022-12-19T12:52:09"}}}}`

Compare this to the actual tap state at https://admin.pathlight.com/admin/dw/tapconfig/cfa9863c-eb7b-4db0-917d-7c01dfaa029e/change/?_changelist_filters=type%3Dgreenhouse.

In practice, we probably only need 1 state field rather than bookmarking state with each individual stream, but this was the simplest change to get the desired behavior so I'm starting with that.