### PR TITLE
FUJ-3165:  bumping version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-greenhouse",
-    version="0.1.5",
+    version="0.2.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
For some reason, this repo already had tags up to 0.1.9 even though setup.py had never been updated.  Making a change to get the versions back in sync.